### PR TITLE
Modified tip3 directory contents

### DIFF
--- a/frontend/docs/updated-tips/3-work-with-frames/csharp.md
+++ b/frontend/docs/updated-tips/3-work-with-frames/csharp.md
@@ -1,6 +1,7 @@
 ---
-title: "How To Work with Frames"
-slug: "3-work-with-frames"
+title: "Work with Frames in CSharp"
+id: "3-work-with-frames-csharp"
+slug: csharp/
 number: 3
 publish_date: 2016-06-12
 last_update: 

--- a/frontend/docs/updated-tips/3-work-with-frames/csharp.md
+++ b/frontend/docs/updated-tips/3-work-with-frames/csharp.md
@@ -1,5 +1,5 @@
 ---
-title: "Work with Frames in CSharp"
+title: "CSharp"
 id: "3-work-with-frames-csharp"
 slug: csharp/
 number: 3

--- a/frontend/docs/updated-tips/3-work-with-frames/java.md
+++ b/frontend/docs/updated-tips/3-work-with-frames/java.md
@@ -1,5 +1,5 @@
 ---
-title: "Work with Frames in Java"
+title: "Java"
 id: "3-work-with-frames-java"
 slug: java/
 number: 3

--- a/frontend/docs/updated-tips/3-work-with-frames/java.md
+++ b/frontend/docs/updated-tips/3-work-with-frames/java.md
@@ -1,6 +1,7 @@
 ---
-title: "How To Work with Frames"
-slug: "3-work-with-frames"
+title: "Work with Frames in Java"
+id: "3-work-with-frames-java"
+slug: java/
 number: 3
 publish_date: 2015-11-09
 last_update: 

--- a/frontend/docs/updated-tips/3-work-with-frames/javascript.md
+++ b/frontend/docs/updated-tips/3-work-with-frames/javascript.md
@@ -1,12 +1,16 @@
 ---
-title: "How To Work with Frames"
-slug: "3-work-with-frames"
+title: "Work with Frames in Javascript"
+id: "3-work-with-frames-javascript"
+slug: javascript/
 number: 3
 publish_date: 2023-02-23
+last_update:
+  date: 2023-03-06
 tags:
   - "frames"
 level: 1
 category: "testing"
+language: javascript
 ---
 
 # How To Work With Frames

--- a/frontend/docs/updated-tips/3-work-with-frames/javascript.md
+++ b/frontend/docs/updated-tips/3-work-with-frames/javascript.md
@@ -1,5 +1,5 @@
 ---
-title: "Work with Frames in Javascript"
+title: "Javascript"
 id: "3-work-with-frames-javascript"
 slug: javascript/
 number: 3

--- a/frontend/docs/updated-tips/3-work-with-frames/python.md
+++ b/frontend/docs/updated-tips/3-work-with-frames/python.md
@@ -1,6 +1,7 @@
 ---
-title: "How To Work with Frames"
-slug: "3-work-with-frames"
+title: "Work with Frames in Python"
+id: "3-work-with-frames-python"
+slug: python/
 number: 3
 publish_date: 2016-11-14
 last_update: 
@@ -12,7 +13,7 @@ category: "testing"
 language: python 
 ---
 
-# How To Work With Frames
+# How To Work with Frames
 
 ## Intro
 

--- a/frontend/docs/updated-tips/3-work-with-frames/python.md
+++ b/frontend/docs/updated-tips/3-work-with-frames/python.md
@@ -1,5 +1,5 @@
 ---
-title: "Work with Frames in Python"
+title: "Python"
 id: "3-work-with-frames-python"
 slug: python/
 number: 3

--- a/frontend/docs/updated-tips/3-work-with-frames/ruby.md
+++ b/frontend/docs/updated-tips/3-work-with-frames/ruby.md
@@ -1,5 +1,5 @@
 ---
-title: 'Work with Frames in Ruby'
+title: 'Ruby'
 id: '3-work-with-frames-ruby'
 slug: ruby/
 number: 3

--- a/frontend/docs/updated-tips/3-work-with-frames/ruby.md
+++ b/frontend/docs/updated-tips/3-work-with-frames/ruby.md
@@ -1,6 +1,7 @@
 ---
-title: 'How To Work with Frames'
-slug: '3-work-with-frames'
+title: 'Work with Frames in Ruby'
+id: '3-work-with-frames-ruby'
+slug: ruby/
 number: 3
 publish_date: 2023-02-21
 last_update: 


### PR DESCRIPTION
Modified Tip3 directory contents (markdown files) to change sidebar structure and URL path.

When tested locally, sidebar and URL were modified and looked like this:

![Screenshot 2023-03-06 175248](https://user-images.githubusercontent.com/24728303/223300531-2862fb79-109a-4062-832a-2cdbdaa4f5a8.png)

![Screenshot 2023-03-06 175310](https://user-images.githubusercontent.com/24728303/223300546-8cd3ef8a-3579-4bed-9ca6-ad4e2ca618a0.png)

**Markdown Metadata changes were as follows:**

![Screenshot 2023-03-06 175334](https://user-images.githubusercontent.com/24728303/223300654-1238fb39-bd17-4069-81bb-ec7223c3340d.png)
