### PR TITLE
Edited metadata for updated tips

### DIFF
--- a/frontend/docs/updated-tips/1-how-to-upload-a-file/javascript.md
+++ b/frontend/docs/updated-tips/1-how-to-upload-a-file/javascript.md
@@ -1,17 +1,18 @@
 ---
-title: "Javascript"
-id: "1-upload-a-file-javascript"
+title: 'Javascript'
+id: '1-upload-a-file-javascript'
 slug: javascript/
 number: 1
 publish_date: 2019-08-09
 last_update: 
   date: 2023-02-22
 tags:
-  - "file"
-  - "upload"
-  - "file upload"
+  - 'file'
+  - 'upload'
+  - 'file upload'
 level: 1
-category: "testing"
+category: 'testing'
+language: javascript
 ---
 # How To Upload A File
 

--- a/frontend/docs/updated-tips/1-how-to-upload-a-file/python.md
+++ b/frontend/docs/updated-tips/1-how-to-upload-a-file/python.md
@@ -1,17 +1,18 @@
 ---
-title: "Python"
-id: "1-upload-a-file-python"
+title: 'Python'
+id: '1-upload-a-file-python'
 slug: python/
 number: 1
 publish_date: 2016-09-13
 last_update: 
   date: 2023-02-22
 tags:
-  - "file"
-  - "upload"
-  - "file upload"
+  - 'file'
+  - 'upload'
+  - 'file upload'
 level: 1
-category: "testing"
+category: 'testing'
+language: python
 ---
 
 # How To Upload A File

--- a/frontend/docs/updated-tips/13-how-to-access-basic-auth/javascript.md
+++ b/frontend/docs/updated-tips/13-how-to-access-basic-auth/javascript.md
@@ -1,15 +1,16 @@
 ---
-title: "How To Access Basic Auth"
-id: "13-work-with-basic-auth-javascript"
+title: 'Javascript'
+id: '13-work-with-basic-auth-javascript'
 slug: javascript/
 number: 13
 publish_date: 2019-08-09
 last_update: 
   date: 2023-02-22
 tags:
-  - "authentication"
+  - 'authentication'
 level: 1
-category: "testing"
+category: 'testing'
+language: javascript
 ---
 
 # How To Access Basic Auth

--- a/frontend/docs/updated-tips/13-how-to-access-basic-auth/python.md
+++ b/frontend/docs/updated-tips/13-how-to-access-basic-auth/python.md
@@ -1,15 +1,16 @@
 ---
-title: "Python"
-id: "13-work-with-basic-auth-python"
+title: 'Python'
+id: '13-work-with-basic-auth-python'
 slug: python/
 number: 13
 publish_date: 2016-11-17
 last_update: 
   date: 2023-02-22
 tags:
-  - "authentication"
+  - 'authentication'
 level: 1
-category: "testing"
+category: 'testing'
+language: python
 ---
 
 # How To Access Basic Auth

--- a/frontend/docs/updated-tips/18-how-to-figure-out-what-to-update/what-to-test.md
+++ b/frontend/docs/updated-tips/18-how-to-figure-out-what-to-update/what-to-test.md
@@ -1,14 +1,15 @@
 ---
-title: "All Languages"
-id: "18-what-to-test"
+title: 'What to Test'
+id: '18-what-to-test'
 number: 18
 publish_date: 2015-10-13
 last_update: 
   date: 2023-02-22
 tags: 
-  - "test strategy"
+  - 'test strategy'
 level: 1
-category: "strategy"
+category: 'strategy'
+language: all
 ---
 
 # How To Figure Out What To Test

--- a/frontend/docs/updated-tips/19-data-driven-testing/ruby.md
+++ b/frontend/docs/updated-tips/19-data-driven-testing/ruby.md
@@ -12,6 +12,7 @@ tags:
   - 'authentication'
 level: 2
 category: 'testing'
+language: ruby
 ---
 
 

--- a/frontend/docs/updated-tips/2-download-a-file/javascript.md
+++ b/frontend/docs/updated-tips/2-download-a-file/javascript.md
@@ -1,20 +1,21 @@
 ---
-title: "Javascript"
-id: "2-download-a-file-javascript"
+title: 'Javascript'
+id: '2-download-a-file-javascript'
 slug: javascript/
 number: 2
 publish_date: 2019-08-09
 last_update: 
   date: 2023-02-22
 tags:
-  - "files"
-  - "downloading"
-  - "file download"
+  - 'files'
+  - 'downloading'
+  - 'file download'
 level: 2
-category: "testing"
+category: 'testing'
+language: javascript
 ---
 
-# Download A File
+# How to Download A File
 
 ## Intro
 

--- a/frontend/docs/updated-tips/2-download-a-file/python.md
+++ b/frontend/docs/updated-tips/2-download-a-file/python.md
@@ -1,20 +1,21 @@
 ---
 title: Python
-id: "2-download-a-file-python"
+id: '2-download-a-file-python'
 slug: python/
 number: 2
 publish_date: 2016-09-23
 last_update: 
   date: 2023-03-02
 tags:
-  - "files"
-  - "downloading"
-  - "file download"
+  - 'files'
+  - 'downloading'
+  - 'file download'
 level: 2
-category: "testing"
+category: 'testing'
+language: python
 ---
 
-# Download A File
+# How to Download A File
 
 ## Intro
 

--- a/frontend/docs/updated-tips/21-adding-a-language/adding-a-language.md
+++ b/frontend/docs/updated-tips/21-adding-a-language/adding-a-language.md
@@ -1,5 +1,5 @@
 ---
-title: 'All Languages'
+title: 'Choosing a Programming Language'
 id: '21-choosing-a-language'
 number: 21
 publish_date: 2015-10-13
@@ -10,6 +10,7 @@ tags:
   - 'frameworks'
 level: 1
 category: 'strategy'
+language: all
 ---
 
 # How To Pick A Programming Language

--- a/frontend/docs/updated-tips/22-locator-strategy/ruby.md
+++ b/frontend/docs/updated-tips/22-locator-strategy/ruby.md
@@ -7,9 +7,9 @@ publish_date: 2013-10-22
 last_update: 
   date: 2023-02-22
 tags:
-  - "locators"
-  - "locator strategy"
-  - "css selectors"
+  - 'locators'
+  - 'locator strategy'
+  - 'css selectors'
 level: 1
 category: 'strategy'
 language: ruby

--- a/frontend/docs/updated-tips/3-work-with-frames/csharp.md
+++ b/frontend/docs/updated-tips/3-work-with-frames/csharp.md
@@ -1,15 +1,15 @@
 ---
-title: "CSharp"
-id: "3-work-with-frames-csharp"
+title: 'CSharp'
+id: '3-work-with-frames-csharp'
 slug: csharp/
 number: 3
 publish_date: 2016-06-12
 last_update: 
   date: 2023-02-22
 tags:
-  - "frames"
+  - 'frames'
 level: 1
-category: "testing"
+category: 'testing'
 language: csharp 
 ---
 

--- a/frontend/docs/updated-tips/3-work-with-frames/java.md
+++ b/frontend/docs/updated-tips/3-work-with-frames/java.md
@@ -1,15 +1,15 @@
 ---
-title: "Java"
-id: "3-work-with-frames-java"
+title: 'Java'
+id: '3-work-with-frames-java'
 slug: java/
 number: 3
 publish_date: 2015-11-09
 last_update: 
   date: 2023-02-22
 tags:
-  - "frames"
+  - 'frames'
 level: 1
-category: "testing"
+category: 'testing'
 language: java 
 ---
 

--- a/frontend/docs/updated-tips/3-work-with-frames/javascript.md
+++ b/frontend/docs/updated-tips/3-work-with-frames/javascript.md
@@ -1,15 +1,15 @@
 ---
-title: "Javascript"
-id: "3-work-with-frames-javascript"
+title: 'Javascript'
+id: '3-work-with-frames-javascript'
 slug: javascript/
 number: 3
 publish_date: 2023-02-23
 last_update:
   date: 2023-03-06
 tags:
-  - "frames"
+  - 'frames'
 level: 1
-category: "testing"
+category: 'testing'
 language: javascript
 ---
 

--- a/frontend/docs/updated-tips/3-work-with-frames/python.md
+++ b/frontend/docs/updated-tips/3-work-with-frames/python.md
@@ -1,15 +1,15 @@
 ---
-title: "Python"
-id: "3-work-with-frames-python"
+title: 'Python'
+id: '3-work-with-frames-python'
 slug: python/
 number: 3
 publish_date: 2016-11-14
 last_update: 
   date: 2023-02-22
 tags:
-  - "frames"
+  - 'frames'
 level: 1
-category: "testing"
+category: 'testing'
 language: python 
 ---
 

--- a/frontend/docs/updated-tips/31-archives/31-archives.md
+++ b/frontend/docs/updated-tips/31-archives/31-archives.md
@@ -1,5 +1,5 @@
 ---
-title: 'All Languages'
+title: 'Accessing Previous Tips Archive'
 id: '31-archives'
 number: 31
 publish_date: 2014-12-23
@@ -9,6 +9,7 @@ tags:
   - 'archives'
 level: 1
 category: 'archives'
+language: all
 ---
 
 # How To Access Previous Tips

--- a/frontend/docs/updated-tips/36-available-resources/36-available-resources
+++ b/frontend/docs/updated-tips/36-available-resources/36-available-resources
@@ -1,23 +1,24 @@
 ---
-title: 'Resources'
+title: 'Selenium Resources'
 id: '36-available-resources'
 number: 36
 publish_date: 2015-10-13
 last_update: 
   date: 2023-02-22
 tags:
-  - "videos"
-  - "talks"
-  - "books"
-  - "chat"
-  - "forums"
-  - "meetups"
-  - "conferences"
-  - "mailing lists"
-  - "resources"
-  - "all the things"
+  - 'videos'
+  - 'talks'
+  - 'books'
+  - 'chat'
+  - 'forums'
+  - 'meetups'
+  - 'conferences'
+  - 'mailing lists'
+  - 'resources'
+  - 'all the things'
 level: 1
 category: 'community'
+language: all
 ---
 
 # Where To Look for Selenium Information

--- a/frontend/docs/updated-tips/4-work-with-multiple-windows/javascript.md
+++ b/frontend/docs/updated-tips/4-work-with-multiple-windows/javascript.md
@@ -1,17 +1,18 @@
 ---
-title: "Javascript"
-id: "4-work-with-multiple-windows-javascript"
+title: 'Javascript'
+id: '4-work-with-multiple-windows-javascript'
 slug: javascript/
 number: 4
 publish_date: 2019-08-09
 last_update: 
   date: 2023-02-22
 tags:
-  - "windows"
-  - "multiple windows"
-  - "new window"
+  - 'windows'
+  - 'multiple windows'
+  - 'new window'
 level: 2
-category: "testing"
+category: 'testing'
+language: javascript
 ---
 
 # Work With Multiple Windows

--- a/frontend/docs/updated-tips/45-how-to-test-checkboxes/csharp.md
+++ b/frontend/docs/updated-tips/45-how-to-test-checkboxes/csharp.md
@@ -1,17 +1,17 @@
 ---
-title: "CSharp"
-id: "45-checkboxes-csharp"
+title: 'CSharp'
+id: '45-checkboxes-csharp'
 slug: csharp/
 number: 45
 publish_date: 2019-08-09
 last_update: 
   date: 2023-02-22
 tags:
-  - "checkboxes"
-  - "attribute"
-  - "selected"
+  - 'checkboxes'
+  - 'attribute'
+  - 'selected'
 level: 1
-category: "testing"
+category: 'testing'
 language: csharp
 ---
 

--- a/frontend/docs/updated-tips/45-how-to-test-checkboxes/java.md
+++ b/frontend/docs/updated-tips/45-how-to-test-checkboxes/java.md
@@ -1,17 +1,17 @@
 ---
-title: "Java"
-id: "45-checkboxes-java"
+title: 'Java'
+id: '45-checkboxes-java'
 slug: java/
 number: 45
 publish_date: 2019-08-09
 last_update: 
   date: 2023-02-22
 tags:
-  - "checkboxes"
-  - "attribute"
-  - "selected"
+  - 'checkboxes'
+  - 'attribute'
+  - 'selected'
 level: 1
-category: "testing"
+category: 'testing'
 language: java
 ---
 

--- a/frontend/docs/updated-tips/45-how-to-test-checkboxes/javascript.md
+++ b/frontend/docs/updated-tips/45-how-to-test-checkboxes/javascript.md
@@ -1,17 +1,17 @@
 ---
-title: "Javascript"
-id: "45-checkboxes-javascript"
+title: 'Javascript'
+id: '45-checkboxes-javascript'
 slug: javascript/
 number: 45
 publish_date: 2019-08-09
 last_update: 
   date: 2023-02-22
 tags:
-  - "checkboxes"
-  - "attribute"
-  - "selected"
+  - 'checkboxes'
+  - 'attribute'
+  - 'selected'
 level: 1
-category: "testing"
+category: 'testing'
 language: javascript
 ---
 

--- a/frontend/docs/updated-tips/45-how-to-test-checkboxes/python.md
+++ b/frontend/docs/updated-tips/45-how-to-test-checkboxes/python.md
@@ -1,17 +1,17 @@
 ---
-title: "Python"
-id: "45-checkboxes-python"
+title: 'Python'
+id: '45-checkboxes-python'
 slug: python/
 number: 45
 publish_date: 2019-08-09
 last_update: 
   date: 2023-03-03
 tags:
-  - "checkboxes"
-  - "attribute"
-  - "selected"
+  - 'checkboxes'
+  - 'attribute'
+  - 'selected'
 level: 1
-category: "testing"
+category: 'testing'
 language: python
 ---
 

--- a/frontend/docs/updated-tips/45-how-to-test-checkboxes/ruby.md
+++ b/frontend/docs/updated-tips/45-how-to-test-checkboxes/ruby.md
@@ -7,9 +7,9 @@ publish_date: 2015-10-13
 last_update: 
   date: 2023-02-22
 tags:
-  - "checkboxes"
-  - "attribute"
-  - "selected"
+  - 'checkboxes'
+  - 'attribute'
+  - 'selected'
 level: 1
 category: 'testing'
 language: ruby

--- a/frontend/docs/updated-tips/5-select-from-a-dropdown/csharp.md
+++ b/frontend/docs/updated-tips/5-select-from-a-dropdown/csharp.md
@@ -1,16 +1,16 @@
 ---
-title: "CSharp"
-id: "5-select-from-a-dropdown-csharp"
+title: 'CSharp'
+id: '5-select-from-a-dropdown-csharp'
 slug: csharp/
 number: 5
 publish_date: 2019-08-09
 last_update: 
   date: 2023-02-22
 tags:
-  - "dropdown"
-  - "forms"
+  - 'dropdown'
+  - 'forms'
 level: 1
-category: "testing"
+category: 'testing'
 language: csharp
 ---
 

--- a/frontend/docs/updated-tips/5-select-from-a-dropdown/java.md
+++ b/frontend/docs/updated-tips/5-select-from-a-dropdown/java.md
@@ -1,16 +1,16 @@
 ---
-title: "Java"
-id: "5-select-from-a-dropdown-java"
+title: 'Java'
+id: '5-select-from-a-dropdown-java'
 slug: java/
 number: 5
 publish_date: 2019-08-09
 last_update: 
   date: 2023-02-22
 tags:
-  - "dropdown"
-  - "forms"
+  - 'dropdown'
+  - 'forms'
 level: 1
-category: "testing"
+category: 'testing'
 language: java
 ---
 

--- a/frontend/docs/updated-tips/5-select-from-a-dropdown/javascript.md
+++ b/frontend/docs/updated-tips/5-select-from-a-dropdown/javascript.md
@@ -1,16 +1,17 @@
 ---
-title: "Javascript"
-id: "5-select-from-a-dropdown-javascript"
+title: 'Javascript'
+id: '5-select-from-a-dropdown-javascript'
 slug: javascript/
 number: 5
 publish_date: 2019-08-09
 last_update: 
   date: 2023-02-22
 tags:
-  - "dropdown"
-  - "forms"
+  - 'dropdown'
+  - 'forms'
 level: 1
-category: "testing"
+category: 'testing'
+language: javascript
 ---
 
 # How To Select From a Dropdown

--- a/frontend/docs/updated-tips/5-select-from-a-dropdown/python.md
+++ b/frontend/docs/updated-tips/5-select-from-a-dropdown/python.md
@@ -1,16 +1,16 @@
 ---
-title: "Python"
-id: "5-select-from-a-dropdown-python"
+title: 'Python'
+id: '5-select-from-a-dropdown-python'
 slug: python/
 number: 5
 publish_date: 2019-08-09
 last_update: 
   date: 2023-03-02
 tags:
-  - "dropdown"
-  - "forms"
+  - 'dropdown'
+  - 'forms'
 level: 1
-category: "testing"
+category: 'testing'
 language: python
 ---
 

--- a/frontend/docs/updated-tips/50-how-to-work-with-hovers/javascript.md
+++ b/frontend/docs/updated-tips/50-how-to-work-with-hovers/javascript.md
@@ -1,17 +1,17 @@
 ---
-title: "Javascript"
-id: "50-hovers-javascript"
+title: 'Javascript'
+id: '50-hovers-javascript'
 slug: javascript/
 number: 50
 publish_date: 2019-08-09
 last_update: 
   date: 2023-02-22
 tags:
-  - "hover"
-  - "hovers"
-  - "action builder"
+  - 'hover'
+  - 'hovers'
+  - 'action builder'
 level: 1
-category: "testing"
+category: 'testing'
 language: javascript
 ---
 

--- a/frontend/docs/updated-tips/50-how-to-work-with-hovers/python.md
+++ b/frontend/docs/updated-tips/50-how-to-work-with-hovers/python.md
@@ -1,17 +1,18 @@
 ---
-title: Python"
-id: "50-hovers-python"
+title: Python'
+id: '50-hovers-python'
 slug: python/
 number: 50
 publish_date: 2016-11-23
 last_update: 
   date: 2023-02-22
 tags:
-  - "hover"
-  - "hovers"
-  - "action builder"
+  - 'hover'
+  - 'hovers'
+  - 'action builder'
 level: 1
-category: "testing"
+category: 'testing'
+language: python
 ---
 
 # How To Work With Hovers

--- a/frontend/docs/updated-tips/50-how-to-work-with-hovers/ruby.md
+++ b/frontend/docs/updated-tips/50-how-to-work-with-hovers/ruby.md
@@ -1,15 +1,15 @@
 ---
-title: "Ruby"
-id: "50-hovers-ruby"
+title: 'Ruby'
+id: '50-hovers-ruby'
 slug: ruby/
 number: 50
 publish_date: 2015-07-01
 last_update: 
   date: 2023-02-22
 tags:
-  - "hover"
-  - "hovers"
-  - "action builder"
+  - 'hover'
+  - 'hovers'
+  - 'action builder'
 level: 1
 category: 'testing'
 language: ruby

--- a/frontend/docs/updated-tips/51-how-to-work-with-javascript-alerts/javascript.md
+++ b/frontend/docs/updated-tips/51-how-to-work-with-javascript-alerts/javascript.md
@@ -1,18 +1,19 @@
 ---
-title: "JavaScript"
-id: "51-javascript-alerts-javascript"
+title: 'JavaScript'
+id: '51-javascript-alerts-javascript'
 slug: javascript/
 number: 51
 publish_date: 2019-08-09
 last_update: 
   date: 2023-02-22
 tags:
-  - "javascript"
-  - "javascript alerts"
-  - "javascript popups"
-  - "javascript dialogs"
+  - 'javascript'
+  - 'javascript alerts'
+  - 'javascript popups'
+  - 'javascript dialogs'
 level: 1
-category: "testing"
+category: 'testing'
+language: javascript
 ---
 
 # How To Work With JavaScript Alerts

--- a/frontend/docs/updated-tips/51-how-to-work-with-javascript-alerts/python.md
+++ b/frontend/docs/updated-tips/51-how-to-work-with-javascript-alerts/python.md
@@ -1,18 +1,19 @@
 ---
-title: "Python"
-id: "51-javascript-alerts-python"
+title: 'Python'
+id: '51-javascript-alerts-python'
 slug: python/
 number: 51
 publish_date: 2016-11-19
 last_update:
   date: 2023-03-03
 tags:
-  - "javascript"
-  - "javascript alerts"
-  - "javascript popups"
-  - "javascript dialogs"
+  - 'javascript'
+  - 'javascript alerts'
+  - 'javascript popups'
+  - 'javascript dialogs'
 level: 1
-category: "testing"
+category: 'testing'
+language: python
 ---
 
 # How To Work With JavaScript Alerts

--- a/frontend/docs/updated-tips/51-how-to-work-with-javascript-alerts/ruby.md
+++ b/frontend/docs/updated-tips/51-how-to-work-with-javascript-alerts/ruby.md
@@ -1,6 +1,6 @@
 ---
-title: "Ruby"
-id: "51-javascript-alerts-ruby"
+title: 'Ruby'
+id: '51-javascript-alerts-ruby'
 slug: ruby/
 number: 51
 publish_date: 2019-08-09

--- a/frontend/docs/updated-tips/57-junit-xml/ruby.md
+++ b/frontend/docs/updated-tips/57-junit-xml/ruby.md
@@ -1,6 +1,6 @@
 ---
 title: 'Ruby'
-id: '"57-junit-xml-ruby'
+id: '57-junit-xml-ruby'
 slug: ruby/
 number: 57
 publish_date: 2015-07-14

--- a/frontend/docs/updated-tips/61-how-to-press-keyboard-keys/javascript.md
+++ b/frontend/docs/updated-tips/61-how-to-press-keyboard-keys/javascript.md
@@ -1,19 +1,19 @@
 ---
-title: "Javascript"
-id: "61-keyboard-keys-javascript"
+title: 'Javascript'
+id: '61-keyboard-keys-javascript'
 slug: javascript/
 number: 61
 publish_date: 2019-08-09
 last_update: 
   date: 2023-02-22
 tags:
-  - "keyboard"
-  - "keys"
-  - "key presses"
-  - "tab"
-  - "enter"
+  - 'keyboard'
+  - 'keys'
+  - 'key presses'
+  - 'tab'
+  - 'enter'
 level: 1
-category: "testing"
+category: 'testing'
 language: javascript
 ---
 

--- a/frontend/docs/updated-tips/61-how-to-press-keyboard-keys/python.md
+++ b/frontend/docs/updated-tips/61-how-to-press-keyboard-keys/python.md
@@ -1,19 +1,20 @@
 ---
-title: "Python"
-id: "61-keyboard-keys-python"
+title: 'Python'
+id: '61-keyboard-keys-python'
 slug: python/
 number: 61
 publish_date: 2016-11-19
 last_update:
     date: 2023-03-03
 tags:
-  - "keyboard"
-  - "keys"
-  - "key presses"
-  - "tab"
-  - "enter"
+  - 'keyboard'
+  - 'keys'
+  - 'key presses'
+  - 'tab'
+  - 'enter'
 level: 1
-category: "testing"
+category: 'testing'
+language: python
 ---
 
 # How To Press Keyboard Keys

--- a/frontend/docs/updated-tips/61-how-to-press-keyboard-keys/ruby.md
+++ b/frontend/docs/updated-tips/61-how-to-press-keyboard-keys/ruby.md
@@ -1,6 +1,6 @@
 ---
 title: 'Ruby'
-id: "61-keyboard-keys-ruby"
+id: '61-keyboard-keys-ruby'
 slug: ruby/
 number: 61
 publish_date: 2015-10-12

--- a/frontend/docs/updated-tips/63-right-click/ruby.md
+++ b/frontend/docs/updated-tips/63-right-click/ruby.md
@@ -1,19 +1,19 @@
 ---
-title: "Ruby"
-id: "63-right-click-ruby"
+title: 'Ruby'
+id: '63-right-click-ruby'
 slug: ruby/
 number: 63
 publish_date: 2015-10-13
 last_update:
   date: 2023-03-06
 tags:
-  - "right-click"
-  - "right click"
-  - "context menu"
-  - "action builder"
-  - "context click"
+  - 'right-click'
+  - 'right click'
+  - 'context menu'
+  - 'action builder'
+  - 'context click'
 level: 2
-category: "testing"
+category: 'testing'
 language: ruby
 ---
 


### PR DESCRIPTION
Edited metadata for updated tips:
-  Fixed some minor typos
-  Added `language` to files that were missing this
-  Changed all double-quotes `"` to single-quotes `'` to match content template, and for consistency throughout files