### PR TITLE
adding contentUrl to Ruby docs and templates

### DIFF
--- a/frontend/docs/updated-tips/0-template/csharp.md
+++ b/frontend/docs/updated-tips/0-template/csharp.md
@@ -1,8 +1,9 @@
 ---
 title: '0: Template'
 id: '0-template-csharp'
+contentUrl: "/docs/updated-tips/0-template/c-sharp"
 # slug: csharp/
-sidebar_label: Csharp
+sidebar_label: CSharp
 text: "This is a template."
 number: 0
 publish_date: 2023-02-17

--- a/frontend/docs/updated-tips/0-template/java.md
+++ b/frontend/docs/updated-tips/0-template/java.md
@@ -1,6 +1,7 @@
 ---
 title: '0: Template'
 id: '0-template-java'
+contentUrl: "docs/updated-tips/template/0-template-java"
 # slug: java/
 sidebar_label: Java
 text: "This is a template."

--- a/frontend/docs/updated-tips/0-template/javascript.md
+++ b/frontend/docs/updated-tips/0-template/javascript.md
@@ -1,6 +1,7 @@
 ---
 title: '0: Template'
 id: '0-template-javascript'
+contentUrl: "docs/updated-tips/template/0-template-javascript"
 # slug: javascript/
 sidebar_label: Javascript
 text: "This is a template."

--- a/frontend/docs/updated-tips/0-template/python.md
+++ b/frontend/docs/updated-tips/0-template/python.md
@@ -1,6 +1,7 @@
 ---
 title: '0: Template'
 id: '0-template-python'
+contentUrl: "docs/updated-tips/template/0-template-python"
 # slug: python/
 sidebar_label: Python
 text: "This is a template."

--- a/frontend/docs/updated-tips/0-template/ruby.md
+++ b/frontend/docs/updated-tips/0-template/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '1: Template'
 id: '0-template-ruby'
+contentUrl: "docs/updated-tips/template/0-template-ruby"
 # slug: ruby/
 sidebar_label: Ruby
 text: "This is a template."

--- a/frontend/docs/updated-tips/1-how-to-upload-a-file/ruby.md
+++ b/frontend/docs/updated-tips/1-how-to-upload-a-file/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '1: How To Upload A File'
 id: '1-upload-a-file-ruby'
+contentUrl: "docs/updated-tips/how-to-upload-a-file/1-upload-a-file-ruby"
 sidebar_label: Ruby
 text: "Uploading a file is a common piece of functionality found on the web but when trying to automate it, you get prompted with a dialog box that is just out of reach for Selenium. In these cases people often look to a third-party tool to manipulate this window AutoIt."
 number: 1

--- a/frontend/docs/updated-tips/10-retry-test-actions-ruby/ruby.md
+++ b/frontend/docs/updated-tips/10-retry-test-actions-ruby/ruby.md
@@ -1,6 +1,7 @@
 ---
 title:'10: Rety Test Actions'
 id: '10-retry-test-actions-ruby'
+contentUrl: "docs/updated-tips/retry-test-actions-ruby/10-retry-test-actions-ruby"
 sidebar_label: Ruby 
 text: "We all write tests with the best intention of having them pass and, when they fail, to reveal legitimate issues in the application we're testing. But that's not always easy to accomplish. Especially when your application is dependent upon third-party service providers (e.g. payment providers, social networks, etc)."
 number: 10

--- a/frontend/docs/updated-tips/11-build-an-interactive-prompt/ruby.md
+++ b/frontend/docs/updated-tips/11-build-an-interactive-prompt/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '11: Build An Interactive Prompt'
 id: '11-build-an-interactive-prompt-ruby'
+contentUrl: "docs/updated-tips/build-an-interactive-prompt/11-build-an-interactive-prompt-ruby"
 sidebar_label: Ruby 
 text: 'Working with Selenium straight in code has its advantages. However, if you run into a complicated scenario to automate, it becomes challenging to work through it to completion.'
 number: 11

--- a/frontend/docs/updated-tips/12-opt-out-of-ab-tests/ruby.md
+++ b/frontend/docs/updated-tips/12-opt-out-of-ab-tests/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '12: Opt Out of AB Tests'
 id: '12-opt-out-of-ab-tests-ruby'
+contentUrl: "docs/updated-tips/opt-out-of-ab-tests/12-opt-out-of-ab-tests-ruby"
 sidebar_label: Ruby 
 text: "Occasionally when running tests you may see unexpected behavior due to A/B testing of the application you're working with. In order to keep your tests running without issue we need a clean way to opt-out of these split tests."
 number: 12

--- a/frontend/docs/updated-tips/13-how-to-access-basic-auth/ruby.md
+++ b/frontend/docs/updated-tips/13-how-to-access-basic-auth/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '13: Work With Basic Auth'
 id: '13-work-with-basic-auth-ruby'
+contentUrl: "docs/updated-tips/how-to-access-basic-auth/13-work-with-basic-auth-ruby"
 sidebar_label: Ruby 
 text: "Sometimes you'll work with applications that are secured behind Basic HTTP Authentication. In order to access them you'll need to pass credentials to the site when requesting a page otherwise you'll get a system level pop-up prompting you for a username and password rendering Selenium helpless."
 number: 13

--- a/frontend/docs/updated-tips/15-download-secure-files/ruby.md
+++ b/frontend/docs/updated-tips/15-download-secure-files/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '15: Download Secure Files'
 id: '15-download-secure-files-ruby'
+contentUrl: "docs/updated-tips/download-secure-files/15-download-secure-files-ruby"
 sidebar_label: Ruby 
 text: "Previously, we've gone over how to test file downloads without a browser by leveraging Selenium Webdriver and an HTTP library in tandem. This approach is great for testing general file downloads, but what if the file you want to download is behind authentication?"
 number: 15

--- a/frontend/docs/updated-tips/16-take-screenshot-on-failure/ruby.md
+++ b/frontend/docs/updated-tips/16-take-screenshot-on-failure/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '16: Take Screenshot on Failure'
 id: '16-take-screenshot-on-failure-ruby'
+contentUrl: "docs/updated-tips/take-screenshot-on-failure/16-take-screenshot-on-failure-ruby"
 sidebar_label: Ruby 
 text: "With browser tests it can often be challenging to track down the issue that caused a failure. By itself, a failure message along with a stack trace is hardly enough to go on, especially when you run the test again and it passes. You may or may not be able to recreate that initial error message, and might be left wondering what it was, and whether or not it will cause issues in the future."
 number: 16

--- a/frontend/docs/updated-tips/17-retrieve-http-status-codes/17-retrieve-http-status-codes.md
+++ b/frontend/docs/updated-tips/17-retrieve-http-status-codes/17-retrieve-http-status-codes.md
@@ -1,6 +1,7 @@
 ---
 title: '17: Retrieve HTTP Status Codes'
 id: '17-retrieve-http-status-codes-ruby'
+contentUrl: "docs/updated-tips/retrieve-http-status-codes/"
 sidebar_label: Ruby
 text: "There are times when you are testing a page (or numerous pages) and you want to verify that it responded correctly. A great way to handle this is by checking the HTTP Status Code that the browser received. However this functionality is not available in Selenium WebDriver."
 number: 17

--- a/frontend/docs/updated-tips/18-how-to-figure-out-what-to-update/what-to-test.md
+++ b/frontend/docs/updated-tips/18-how-to-figure-out-what-to-update/what-to-test.md
@@ -1,6 +1,7 @@
 ---
 title: '18: How To Figure Out What to Update'
 id: '18-what-to-test'
+contentUrl: "docs/updated-tips/how-to-figure-out-what-to-update/18-what-to-test"
 sidebar_label: Ruby
 text: "There is a lot to figure out when it comes to automated web testing, but where do you start? If you've already started, how do you know you're on the right track? And how do you avoid testing everything in every browser without missing important issues?"
 number: 18

--- a/frontend/docs/updated-tips/19-data-driven-testing/ruby.md
+++ b/frontend/docs/updated-tips/19-data-driven-testing/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '19: Data Driven Testing'
 id: '19-data-driven-testing-ruby'
+contentUrl: "docs/updated-tips/data-driven-testing/19-data-driven-testing-ruby"
 sidebar_label: Ruby 
 text: "There are times when you run across functionality you want to test repeatedly with various inputs to see how the system behaves. We're going to go over a way to do this that will take some of the burden out of the process."
 number: 19

--- a/frontend/docs/updated-tips/2-download-a-file/ruby.md
+++ b/frontend/docs/updated-tips/2-download-a-file/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '2: Download A File'
 id: '2-download-a-file-ruby'
+contentUrl: "docs/updated-tips/download-a-file/2-download-a-file-ruby"
 sidebar_label: Ruby
 text: "Just like with uploading files we hit the same issue with downloading them a dialog box just out of Selenium's reach. With some additional configuration, we can side-step the dialog box."
 number: 2

--- a/frontend/docs/updated-tips/21-adding-a-language/adding-a-language.md
+++ b/frontend/docs/updated-tips/21-adding-a-language/adding-a-language.md
@@ -1,6 +1,7 @@
 ---
 title: '21: Choosing a Programming Language'
 id: '21-choosing-a-language'
+contentUrl: "docs/updated-tips/adding-a-language/21-choosing-a-language"
 text: "In order to work well with Selenium you need to choose a programming language to write your acceptance tests in. This guide will help you determine which language to choose for testing."
 number: 21
 publish_date: 2015-10-13

--- a/frontend/docs/updated-tips/22-locator-strategy/ruby.md
+++ b/frontend/docs/updated-tips/22-locator-strategy/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '22: Locator Strategy'
 id: '22-locator-strategy-ruby'
+contentUrl: "docs/updated-tips/locator-strategy/22-locator-strategy-ruby"
 sidebar_label: Ruby 
 text: "In web design CSS (Cascading Style Sheets) is used to apply styles to the markup (HTML) on a page. CSS is able to do this by declaring which bits of the the markup it wants to interact with through the use of selectors."
 number: 22

--- a/frontend/docs/updated-tips/23-dynamic-pages/ruby.md
+++ b/frontend/docs/updated-tips/23-dynamic-pages/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '23: Dynamic Pages'
 id: '23-dynamic-pages-ruby'
+contentUrl: "docs/updated-tips/dynamic-pages/23-dynamic-pages-ruby"
 sidebar_label: Ruby 
 text: "Let's say you want to test some functionality of a web application but it loads things dynamically. You might think about using a hard-coded sleep (that you constantly tweak due to test failures) or you use a blanket timeout that you likely bump up to address test instabilities as well."
 number: 23

--- a/frontend/docs/updated-tips/24-rest-apis/ruby.md
+++ b/frontend/docs/updated-tips/24-rest-apis/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '24: REST APIs'
 id: '24-rest-apis-ruby'
+contentUrl: "docs/updated-tips/rest-apis/24-rest-apis-ruby"
 sidebar_label: Ruby 
 text: "When we list out the properties that make a test a good test, some things that often come up are: Precise. The test should test one thing, and one thing only. A bug in some part of the application that is unrelated to the test should not cause the test to fail."
 number: 24

--- a/frontend/docs/updated-tips/25-how-to-work-with-tables/ruby.md
+++ b/frontend/docs/updated-tips/25-how-to-work-with-tables/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '25: How To Work With Tables'
 id: '25-tables-ruby'
+contentUrl: "docs/updated-tips/how-to-work-with-tables/25-tables-ruby"
 sidebar_label: Ruby
 text: "Odds are at some point you've come across the use of tables in a web application to display data or information to a user, giving them the option to sort and manipulate it. Depending on your application it can be quite common and something you will want to write an automated test for."
 number: 25

--- a/frontend/docs/updated-tips/26-cloud/ruby.md
+++ b/frontend/docs/updated-tips/26-cloud/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '26: Cloud'
 id: '26-cloud-ruby'
+contentUrl: "docs/updated-tips/cloud/26-cloud-ruby"
 sidebar_label: Ruby 
 text: "In order to test features in a previous version of Chrome, you would need to run a virtual machine (VM) on your computer with a legit version of Windows installed on the VM."
 number: 0

--- a/frontend/docs/updated-tips/29-chrome-driver/ruby.md
+++ b/frontend/docs/updated-tips/29-chrome-driver/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '29: Chrome Driver'
 id: 29-chrome-driver-ruby
+contentUrl: "docs/updated-tips/chrome-driver/29-chrome-driver-ruby"
 sidebar_label: Ruby 
 text: "It's straightforward to get your tests running locally against Firefox. But when you want to run them against a different browser like Chrome, you quickly run into configuration overhead that can seem overly complex and lacking in code examples for getting started."
 number: 29

--- a/frontend/docs/updated-tips/3-work-with-frames/ruby.md
+++ b/frontend/docs/updated-tips/3-work-with-frames/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '3: Work With Frames'
 id: '3-work-with-frames-ruby'
+contentUrl: "docs/updated-tips/work-with-frames/3-work-with-frames-ruby"
 sidebar_label: Ruby
 text: "In this tip, you'll learn how to work with frames and write tests against them. On occasion, we may encounter relics of the front-end world, such as frames."
 number: 3

--- a/frontend/docs/updated-tips/31-archives/31-archives.md
+++ b/frontend/docs/updated-tips/31-archives/31-archives.md
@@ -1,6 +1,7 @@
 ---
 title: 'Accessing Previous Tips Archive'
 id: '31-archives'
+contentUrl: "docs/updated-tips/archives/"
 sidebar_label: Ruby
 text: "Let me guess you subscribed to a free, weekly Selenium tip newsletter and aren't sure of how to access
 previously written tips or are unaware that this is even a possibility."

--- a/frontend/docs/updated-tips/36-available-resources/36-available-resources
+++ b/frontend/docs/updated-tips/36-available-resources/36-available-resources
@@ -1,6 +1,7 @@
 ---
 title: 'Selenium Resources'
 id: '36-available-resources'
+contentUrl: "docs/updated-tips/available-resources/36-availavble-resources"
 sidebar_label: Ruby
 text: "This is the official Selenium documentation site. There is a lot of helpful information here. Use the sidebar menu on the left to navigate."
 number: 36

--- a/frontend/docs/updated-tips/39-drag-and-drop/ruby.md
+++ b/frontend/docs/updated-tips/39-drag-and-drop/ruby.md
@@ -1,8 +1,9 @@
 ---
-title: '39: Drag and Drop'
+title: '39: How to Test HTML5 Drag and Drop'
 id: '39-drag-and-drop-ruby'
+contentUrl: "docs/updated-tips/drag-and-drop/39-drag-and-drop-ruby"
 sidebar_label: Ruby
-text: 'Exercising a page's drag-and-drop functionality used to be simple with [Selenium's Action Builder](http://selenium.googlecode.com/svn/trunk/docs/api/rb/Selenium/WebDriver/ActionBuilder.html), but sadly, [it won't work with HTML5 drag and drop](https://code.google.com/p/selenium/issues/detail?id=6315).'
+text: "Exercising a page's drag-and-drop functionality used to be simple with Selenium's Action Builder, but sadly, it won't work with HTML5 drag and drop."
 number: 39
 publish_date: 2014-02-25
 last_update:

--- a/frontend/docs/updated-tips/4-work-with-multiple-windows/ruby.md
+++ b/frontend/docs/updated-tips/4-work-with-multiple-windows/ruby.md
@@ -1,6 +1,7 @@
 ---
 title:'4: Work With Multiple Windows'
 id: '4-work-with-multiple-windows-ruby'
+contentUrl: "docs/updated-tips/work-with-multiple-windows/4-work-with-multiple-windows-ruby"
 sidebar_label: Ruby 
 text: "This tip will explain how to work with multiple windows in Selenium and switch between them. Occasionally you'll run into a link or action in the application you're testing that will open a new window."
 number: 4

--- a/frontend/docs/updated-tips/40-disabled-element/ruby.md
+++ b/frontend/docs/updated-tips/40-disabled-element/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '40: Disabled Element'
 id: '40-disabled-element-ruby'
+contentUrl: "docs/updated-tips/disabled-element/40-disabled-element-ruby"
 sidebar_label: Ruby 
 text: "On occasion you may have the need to check if an element on a page is disabled or enabled. Unfortunately, this is not a well-documented function of Selenium, so doing a trivial action like this can quickly become a pain."
 number: 40

--- a/frontend/docs/updated-tips/44-exception-handling/ruby.md
+++ b/frontend/docs/updated-tips/44-exception-handling/ruby.md
@@ -1,7 +1,8 @@
 ---
-title: '44: Exception Handling'
+title: '44: How To Handle Exceptions'
 sidebar_label: Ruby
-text: "It doesn't take long when using Selenium before you run into errors from Selenium that may seem inexplicable (e.g., `NoSuchElementError` or `StaleElementReferenceError`). They can be a bit of a shock if you're not sure what they are, how to handle them, or where to find documentation on how to address them."
+contentUrl: "docs/updated-tips/exception-handling/ruby"
+text: "It doesn't take long when using Selenium before you run into errors from Selenium that may seem inexplicable . They can be a bit of a shock if you're not sure what they are, how to handle them, or where to find documentation on how to address them."
 number: 44
 publish_date: 2015-07-01
 last_update:

--- a/frontend/docs/updated-tips/45-how-to-test-checkboxes/ruby.md
+++ b/frontend/docs/updated-tips/45-how-to-test-checkboxes/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '45: How To Test Checkboxes'
 id: '45-checkboxes-ruby'
+contentUrl: "docs/updated-tips/how-to-test-checkboxes/45-checkboxes-ruby"
 sidebar_label: Ruby 
 text: "Checkboxes are an often used element in web applications. This guide will show you how to work with them in your Selenium tests."
 number: 45

--- a/frontend/docs/updated-tips/47-waiting/ruby.md
+++ b/frontend/docs/updated-tips/47-waiting/ruby.md
@@ -1,6 +1,7 @@
 ---
-title: '47: Waiting'
+title: '47: Implicit vs Explicit Waits'
 id: 47-waiting-ruby
+contentUrl: "docs/updated-tips/waiting/47-waiting-ruby"
 sidebar_label: Ruby 
 text: "In order to make our Selenium tests resilient, we need to make them wait for certain elements to load. Elements that we want to interact with. This is especially true with JavaScript heavy pages."
 number: 47

--- a/frontend/docs/updated-tips/48-load-testing/48-load-testing-ruby.md
+++ b/frontend/docs/updated-tips/48-load-testing/48-load-testing-ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '48: Load Testing'
 id: '48-load-testing-ruby'
+contentUrl: "docs/updated-tips/load-testing/48-load-testing-ruby"
 sidebar_label: Ruby 
 text: "How do you do load testing in Selenium? While there are plenty of resources citing that while it _can_ be done, there are better tools for the job. Tools like JMeter are often recommended, but they can be intimidating and challenging to get started."
 number: 48

--- a/frontend/docs/updated-tips/49-performance-testing/49-performance-testing-ruby.md
+++ b/frontend/docs/updated-tips/49-performance-testing/49-performance-testing-ruby.md
@@ -1,6 +1,7 @@
 ---
-title: '49: Performance Testing'
+title: '49: How to Do Performance Testing'
 id: '49-performance-testing-ruby'
+contentUrl: "docs/updated-tips/performance-testing/49-performance-testing-ruby"
 sidebar_label: Ruby 
 text: "Odds are pretty good that your production application has some kind of performance monitoring in place (e.g., New Relic). This goes a long way towards identifying when something detrimental has been released into the wild."
 # slug: ruby/

--- a/frontend/docs/updated-tips/5-select-from-a-dropdown/ruby.md
+++ b/frontend/docs/updated-tips/5-select-from-a-dropdown/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '5: Select From A Dropdown'
 id: '5-select-from-a-dropdown-ruby'
+contentUrl: "docs/updated-tips/select-from-a-dropdown/5-select-from-a-dropdown-ruby"
 sidebar_label: Ruby
 text: "Some common use cases for selecting from a dropdown list might be selecting sizes or styles from a dropdown menu while online shopping, or selecting your method of payment. And, while selecting from a dropdown list might seem straightforward just grab the list by its element and select an item within it, based on the text you want there's a bit more skill to it."
 number: 5

--- a/frontend/docs/updated-tips/50-how-to-work-with-hovers/ruby.md
+++ b/frontend/docs/updated-tips/50-how-to-work-with-hovers/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '50: How To Work With Hovers'
 id: '50-hovers-ruby'
+contentUrl: "docs/updated-tips/how-to-work-with-hovers/50-hovers-ruby"
 sidebar_label: Ruby 
 text: "If you need to work with mouse hovers in your tests, it might not be obvious how to do this with Selenium. A quick search through the official Selenium documentation can also be confusing, and might leave you scouring online forums and search engines for the solution."
 number: 50

--- a/frontend/docs/updated-tips/51-how-to-work-with-javascript-alerts/ruby.md
+++ b/frontend/docs/updated-tips/51-how-to-work-with-javascript-alerts/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '51: How To Work With JavaScript Alerts'
 id: '51-javascript-alerts-ruby'
+contentUrl: "docs/updated-tips/how-to-work-with-javascript-alerts/51-javascript-alerts-ruby"
 sidebar_label: Ruby 
 text: 'Built into Selenium is the ability to switch to an alert window and either accept or dismiss it. This way your tests can continue unencumbered by dialog boxes that may feel just out of reach.'
 number: 51

--- a/frontend/docs/updated-tips/53-growl/ruby.md
+++ b/frontend/docs/updated-tips/53-growl/ruby.md
@@ -1,8 +1,9 @@
 ---
 title: '53: Growl'
 id: 53-growl-ruby
+contentUrl: "docs/updated-tips/growl/53-growl-ruby"
 sidebar_label: Ruby 
-text: 'Good test reports are a fundamental component of successful test automation, but running down a test failure by looking at a test report can be a real pain sometimes. Oftentimes, you're left to decipher debug statements, or go through things piece by piece -- all for the sake of trying to track down a transient issue.'
+text: "Good test reports are a fundamental component of successful test automation, but running down a test failure by looking at a test report can be a real pain sometimes. Oftentimes, you're left to decipher debug statements, or go through things piece by piece all for the sake of trying to track down a transient issue."
 number: 53
 publish_date: 2016-11-22
 last_update:

--- a/frontend/docs/updated-tips/55-wrapper/ruby.md
+++ b/frontend/docs/updated-tips/55-wrapper/ruby.md
@@ -1,7 +1,9 @@
 ---
 title: '55: Wrapper'
 id: '55-wrapper-ruby'
-slug: ruby/
+contentUrl: "docs/updated-tips/wrapper/55-wrapper-ruby"
+sidebar_label: Ruby 
+text: "There may come a time where you want to access Selenium logs in real time. Although there is a way to do this where you have to explicitly request the logs after each test action, what if we wanted information for every test action?"
 number: 55
 publish_date: 2014-06-17
 last_update:

--- a/frontend/docs/updated-tips/57-junit-xml/ruby.md
+++ b/frontend/docs/updated-tips/57-junit-xml/ruby.md
@@ -1,8 +1,9 @@
 ---
 title: '57: Junit XML'
 id: '57-junit-xml-ruby'
+contentUrl: "docs/updated-tips/junit-xml/57-junit-xml-ruby"
 sidebar_label: Ruby
-text: 'If you want your Selenium tests to automatically run and report failures to you and your team, you'll want to wire them up to a [Continuous Integration](http://en.wikipedia.org/wiki/Continuous_integration) (CI) server.'
+text: "If you want your Selenium tests to automatically run and report failures to you and your team, you'll want to wire them up to a Continuous Integration server."
 number: 57
 publish_date: 2015-07-14
 last_update:

--- a/frontend/docs/updated-tips/58-tagging/ruby.md
+++ b/frontend/docs/updated-tips/58-tagging/ruby.md
@@ -1,7 +1,7 @@
 ---
-
 title: '58: Tagging'
 id: '58-tagging-ruby'
+contentUrl: "docs/updated-tips/tagging/58-tagging-ruby"
 sidebar_label: Ruby
 text: "As your test suite grows you'll likely employ some kind of folder structure to help make sense of everything -- grouping similar tests together. But what do you do when you want to run a set of tests that span across your organizational structure? Especially when your organizational structure isn't set in stone?"
 number: 58

--- a/frontend/docs/updated-tips/60-list-tags/ruby.md
+++ b/frontend/docs/updated-tips/60-list-tags/ruby.md
@@ -1,7 +1,7 @@
 ---
-
 title: '60: List Tags'
 id: '60-list-tags-ruby'
+contentUrl: "docs/updated-tips/list-tags/60-list-tags-ruby"
 sidebar_label: Ruby
 text: "Tagging is a powerful tool for targeted test execution, as well as a lightweight form of documentation. But what happens when you want to see a summary of the tags you're using across all of your tests? Unfortunately, most solution don't offer this kind of functionality out of the box, leaving you to manually sift through your tests to get a sense of the different tags you're using."
 number: 60

--- a/frontend/docs/updated-tips/61-how-to-press-keyboard-keys/ruby.md
+++ b/frontend/docs/updated-tips/61-how-to-press-keyboard-keys/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '61: How To Press Keyboard Keys'
 id: '61-keyboard-keys-ruby'
+contentUrl: "docs/updated-tips/how-to-press-keyboard-keys/61-keyboard-keys-ruby"
 sidebar_label: Ruby 
 text: "On occasion you'll come across functionality that requires the use of keyboard key presses in your tests. Perhaps you'll need to tab to traverse from one portion of the page to another, back out of some kind of menu or overlay with the escape key, or even submit a form with Enter. But how do you do it and where do you start?"
 number: 61

--- a/frontend/docs/updated-tips/63-right-click/ruby.md
+++ b/frontend/docs/updated-tips/63-right-click/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '63: Right Click'
 id: '63-right-click-ruby'
+contentUrl: "docs/updated-tips/right-click/63-right-click-ruby"
 sidebar_label: Ruby 
 text: "Sometimes you'll run into an app that has functionality hidden behind a right-click menu (a.k.a. a context menu). These menus tend to be system level menus that are untouchable by Selenium. So how do you test this functionality?"
 number: 63

--- a/frontend/docs/updated-tips/64-limit-bandwidth/64-limit-bandwidth-ruby.md
+++ b/frontend/docs/updated-tips/64-limit-bandwidth/64-limit-bandwidth-ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '64: Limit Bandwidth'
 id: '64-limit-bandwidth-ruby'
+contentUrl: "docs/updated-tips/limit-bandwidth/64-limit-bandwidth-ruby"
 sidebar_label: Ruby 
 text: "With Selenium you have the luxury of cross browser testing. But what happens when you also need to test how your application behaves on a _slow_ connection?"
 number: 64

--- a/frontend/docs/updated-tips/65-highlight-elements/ruby.md
+++ b/frontend/docs/updated-tips/65-highlight-elements/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '65: Highlight Elements'
 id: '65-highlight-elements-ruby'
+contentUrl: "docs/updated-tips/highlight-elements/65-highlight-elements-ruby"
 sidebar_label: Ruby 
 text: "It's likely that you'll run into odd test behavior that makes you question the locators you're using in a test. But how do you interrogate your locators to make sure they are doing what you expect?"
 number: 65

--- a/frontend/docs/updated-tips/66-blacklist/66-blacklist-ruby.md
+++ b/frontend/docs/updated-tips/66-blacklist/66-blacklist-ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '66: Blacklist'
 id: '66-blacklist-ruby'
+contentUrl: "docs/updated-tips/blacklist/66-blacklist-ruby"
 sidebar_label: Ruby 
 text: "There are plenty of external resources that get loaded onto a page that aren't directly relevant to the functionality you're testing (e.g., Facebook widgets, Analytics, JavaScript snippets, etc.). And these external resources have the potential to negatively impact your test runs due to slow load times."
 number: 66

--- a/frontend/docs/updated-tips/67-broken-images/67-broken-images-ruby.md
+++ b/frontend/docs/updated-tips/67-broken-images/67-broken-images-ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '67: Broken Images'
 id: '67-broken-images-ruby'
+contentUrl: "docs/updated-tips/broken-images/67-broken-images-ruby"
 sidebar_label: Ruby 
 text: "Selenium is built to mimic human action (e.g., clicking, typing, dragging, dropping, etc.). So how do you use it to test for broken images?"
 number: 67

--- a/frontend/docs/updated-tips/68-load-testing-revisited/68-load-testing-revisited-ruby.md
+++ b/frontend/docs/updated-tips/68-load-testing-revisited/68-load-testing-revisited-ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '68: Load Testing Revisited'
 id: '68-load-testing-revisited-ruby'
+contentUrl: "docs/updated-tips/load-testing-revisited/68-load-testing-revisited-ruby"
 sidebar_label: Ruby 
 text: "In [a previous tip](http://elementalselenium.com/tips/48-load-testing) I demonstrated a way to accomplish a simple load test with a Selenium script and an HTTP library. While it works, it's only useful for rudimentary test cases. For more involved test cases and more powerful load generation, we're going to need something stronger."
 number: 68

--- a/frontend/docs/updated-tips/69-safari/ruby.md
+++ b/frontend/docs/updated-tips/69-safari/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '69: Safari'
 id: '69-safari-ruby'
+contentUrl: "docs/updated-tips/safari/69-safari-ruby"
 sidebar_label: Ruby 
 text: "Since Selenium 2.45.0, in order to use SafariDriver, you need to manually install the SafariDriver browser extension."
 number: 69

--- a/frontend/docs/updated-tips/7-use-a-page-object/ruby.md
+++ b/frontend/docs/updated-tips/7-use-a-page-object/ruby.md
@@ -1,6 +1,7 @@
 ---
 title:'7: Use A Page Object'
 id: '7-use-a-page-object-ruby'
+contentUrl: "docs/updated-tips/use-a-page-object/7-use-a-page-object-ruby"
 sidebar_label: Ruby 
 text: "One of the biggest challenges with Selenium tests is that they can be brittle and challenging to maintain over time.
 This is largely due to the fact that things in the app you're testing change, breaking your tests."

--- a/frontend/docs/updated-tips/71-mobile-testing-pyramid/mobile-testing-pyramid.md
+++ b/frontend/docs/updated-tips/71-mobile-testing-pyramid/mobile-testing-pyramid.md
@@ -1,7 +1,10 @@
 ---
 title: 'The Mobile Testing Pyramid'
 id: '71-mobile-testing-pyramid'
-slug: mobile-testing-pyramid/
+# slug: mobile-testing-pyramid/
+contentUrl: "docs/updated-tips/mobile-testing-pyramid/71-mobile-testing-pyramid"
+sidebar_label: Ruby 
+text: "There are loads of trade-offs when it comes to mobile testing. But by learning to use all layers of the mobile testing pyramid to your advantage you can gain the fast feedback that is required in modern CI/CD environments."
 number: 71
 publish_date: 2017-08-10
 last_update:

--- a/frontend/docs/updated-tips/72-headless-chrome/ruby.md
+++ b/frontend/docs/updated-tips/72-headless-chrome/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '72: Headless Chrome'
 id: '72-headless-chrome-ruby'
+contentUrl: "docs/updated-tips/headless-chrome/72-headless-chrome-ruby"
 sidebar_label: Ruby 
 text: "If you want to run your tests headlessly on a Continuous Integration (CI) server you'll quickly realize that you can't with an out-of-the-box setup since there is no display output for the browser to launch in."
 number: 72

--- a/frontend/docs/updated-tips/73-open-new-window/ruby.md
+++ b/frontend/docs/updated-tips/73-open-new-window/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '73: Open New Window'
 id: '73-open-new-window-ruby'
+contentUrl: "docs/updated-tips/open-new-window/73-open-new-window-ruby"
 sidebar_label: Ruby 
 text: "Nearly everyone, at some point during their normal flow of work on the computer, has had to open a new window or tab. In fact, many of us often end up with several tabs open. It makes sense that this should be tested using Selenium."
 number: 73

--- a/frontend/docs/updated-tips/8-download-a-file-revisited/ruby.md
+++ b/frontend/docs/updated-tips/8-download-a-file-revisited/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: '8: Download A File Revisited'
 id: '8-download-a-file-revisited-ruby'
+contentUrl: "docs/updated-tips/download-a-file-revisited/8-download-a-file-revisited-ruby"
 sidebar_label: Ruby 
 text: "In a previous tip we went through how to download files with Selenium by configuring the browser to download them locally and verifying their file size when done. While the previous method works, it requires a custom configuration that is inconsistent from browser to browser."
 number: 8

--- a/frontend/docs/updated-tips/9-use-a-base-page-object/ruby.md
+++ b/frontend/docs/updated-tips/9-use-a-base-page-object/ruby.md
@@ -1,6 +1,7 @@
 ---
 title:'9: Use A Base Page Object'
 id: '9-use-a-base-page-object-ruby'
+contentUrl: "docs/updated-tips/use-a-base-page-object/9-use-a-base-page-object-ruby"
 sidebar_label: Ruby
 text: "In a previous tip, we went through creating a simple Page Object to capture the behavior of a page we were interacting with. While this was a good start, it leaves a lot of room for improvement. One of the biggest issues is that there are common actions we will likely need across multiple Page Objects and, with our current approach, we would end up with duplicate code."
 number: 9

--- a/frontend/src/data.js
+++ b/frontend/src/data.js
@@ -5,7 +5,7 @@ const Data = [
         text: "Uploading a file is a common piece of functionality found on the web. But when trying to automate it you get prompted with a with a dialog box...", 
         difficulty: "Beginner", 
         category: ["fundamentals", "remote"],
-        contentUrl: "http://localhost:3000/elemental-next/docs/updated-tips/how-to-upload-a-file/ruby/",
+        contentUrl: "docs/updated-tips/how-to-upload-a-file/1-upload-a-file-ruby",
         tags: ["files", "upload", "file_upload"]
     },
     { 


### PR DESCRIPTION
new data added labeled as contentUrl with the same format as the file structure starting from the docs file.

e.g. `contentUrl: "docs/updated-tips/open-new-window/73-open-new-window-ruby"`

**it ends with the id of the tip**